### PR TITLE
Add extension interface

### DIFF
--- a/controller/auth/impl.go
+++ b/controller/auth/impl.go
@@ -20,7 +20,7 @@ func New(svc *service.Service) *AuthController {
 
 func (controller *AuthController) GetOAuthRedirect(ctx *context.Context) error {
 	provider := ctx.Param("provider")
-	target := ctx.Param("target")
+	target := ctx.QueryParam("target")
 	if target == "" {
 		target = "/"
 	}

--- a/controller/auth/impl.go
+++ b/controller/auth/impl.go
@@ -20,8 +20,12 @@ func New(svc *service.Service) *AuthController {
 
 func (controller *AuthController) GetOAuthRedirect(ctx *context.Context) error {
 	provider := ctx.Param("provider")
+	target := ctx.Param("target")
+	if target == "" {
+		target = "/"
+	}
 
-	uri, err := controller.svc.Auth.GetOAuthRedirect(provider)
+	uri, err := controller.svc.Auth.GetOAuthRedirect(provider, target)
 	if err != nil {
 		ctx.String(http.StatusBadRequest, "Invalid Provider")
 		return err

--- a/service/auth/impl.go
+++ b/service/auth/impl.go
@@ -24,13 +24,13 @@ type authImpl struct {
 	db *sqlx.DB
 }
 
-func (service *authImpl) GetOAuthRedirect(providerName string) (string, error) {
+func (service *authImpl) GetOAuthRedirect(providerName string, target string) (string, error) {
 	oauthProvider, err := provider.GetProvider(providerName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get oauth provider %s: %w", providerName, err)
 	}
 
-	return oauthProvider.GetOAuthRedirect()
+	return oauthProvider.GetOAuthRedirect(target)
 }
 
 func (service *authImpl) Authorize(providerName string, code string) (*model.Token, error) {

--- a/service/auth/interface.go
+++ b/service/auth/interface.go
@@ -8,7 +8,7 @@ import (
 )
 
 type AuthService interface {
-	GetOAuthRedirect(providerName string) (string, error)
+	GetOAuthRedirect(providerName string, target string) (string, error)
 	Authorize(providerName string, code string) (*model.Token, error)
 	Verify(token string) (string, error)
 }

--- a/service/auth/provider/fake.go
+++ b/service/auth/provider/fake.go
@@ -2,7 +2,7 @@ package provider
 
 type FakeOAuth struct{}
 
-func (oauth *FakeOAuth) GetOAuthRedirect() (string, error) {
+func (oauth *FakeOAuth) GetOAuthRedirect(target string) (string, error) {
 	return "http://fake.oauth", nil
 }
 

--- a/service/auth/provider/google.go
+++ b/service/auth/provider/google.go
@@ -35,6 +35,7 @@ func (oauth *GoogleOAuth) GetOAuthRedirect(target string) (string, error) {
 		"scope":         "profile email",
 		"response_type": "code",
 		"redirect_uri":  redirectUri,
+		"state":         target,
 	}
 
 	query := uri.Query()

--- a/service/auth/provider/google.go
+++ b/service/auth/provider/google.go
@@ -13,7 +13,7 @@ import (
 
 type GoogleOAuth struct{}
 
-func (oauth *GoogleOAuth) GetOAuthRedirect() (string, error) {
+func (oauth *GoogleOAuth) GetOAuthRedirect(target string) (string, error) {
 	clientId, err := config.GetConfigValue("OAUTH_GOOGLE_ID")
 	if err != nil {
 		return "", fmt.Errorf("failed to get client id: %w", err)

--- a/service/auth/provider/interface.go
+++ b/service/auth/provider/interface.go
@@ -7,7 +7,7 @@ import (
 )
 
 type OAuthProvider interface {
-	GetOAuthRedirect() (string, error)
+	GetOAuthRedirect(target string) (string, error)
 	GetOAuthToken(code string) (string, error)
 	GetVerifiedEmail(token string) (string, error)
 }

--- a/template/redirect.html
+++ b/template/redirect.html
@@ -6,7 +6,7 @@
     const code = (new URLSearchParams(window.location.search)).get("code");
     const provider = {{.Provider}};
 
-    const target = (new URLSearchParams(window.location.search)).get("state");
+    var target = (new URLSearchParams(window.location.search)).get("state");
     if (target == null) {
         target = "/";
     }

--- a/template/redirect.html
+++ b/template/redirect.html
@@ -16,23 +16,21 @@
     if (target[0] != '/') {
         target += '?code=' + code;
         window.location.replace(target);
-        return;
+    } else {
+        fetch("/api/auth/" + provider, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                code: code,
+            }),
+        }).then(res => {
+            return res.json();
+        }).then(data => {
+            window.location.replace(target);
+        })
     }
-
-    fetch("/api/auth/" + provider, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-            code: code,
-        }),
-    }).then(res => {
-        return res.json();
-    }).then(data => {
-        window.location.replace(target);
-    }
-    )
 </script>
 Verifying Acount...
 

--- a/template/redirect.html
+++ b/template/redirect.html
@@ -6,10 +6,23 @@
     const code = (new URLSearchParams(window.location.search)).get("code");
     const provider = {{.Provider}};
 
+    const target = (new URLSearchParams(window.location.search)).get("state");
+    if (target == null) {
+        target = "/";
+    }
+
+    // TODO: Use proper parsing of the query params on the
+    // target, then update then and reserialize into a uri
+    if (target[0] != '/') {
+        target += '?code=' + code;
+        window.location.replace(target);
+        return;
+    }
+
     fetch("/api/auth/" + provider, {
         method: "POST",
         headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
         },
         body: JSON.stringify({
             code: code,
@@ -17,7 +30,7 @@
     }).then(res => {
         return res.json();
     }).then(data => {
-        window.location.replace("/");
+        window.location.replace(target);
     }
     )
 </script>

--- a/test/service/auth/auth_test.go
+++ b/test/service/auth/auth_test.go
@@ -39,7 +39,7 @@ func TestGetOAuthRedirect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	uri, err := svc.GetOAuthRedirect(provider)
+	uri, err := svc.GetOAuthRedirect(provider, "/")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #7 

This allows extensions to core to call into the login flow and specify a redirect back to their sites. The extensions will receive a code which they can exchange for an ACM@UIUC Core token by posting to the endpoint for their specified oauth provider. Once the extension has received the token from this exchange it can perform operations such as obtaining a user's username and verifying their group membership.