### PR TITLE
Use local data in dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ run:
 	@echo 'Starting ACM@UIUC Core'
 	@$(REPO_ROOT)/scripts/run.sh
 
+# Runs the existing binary in dev mode
+.PHONY: run-dev
+run-dev:
+	@echo 'Starting ACM@UIUC Core'
+	@$(REPO_ROOT)/scripts/run-dev.sh
+
 # Formats the repo's golang files
 .PHONY: fmt
 fmt:

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+trap cleanup INT
+
+function cleanup {
+	echo "Cleaning up..."
+	exit 0
+}
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+IS_DEV="true" \
+GITSTORE_BASE_URI="$REPO_ROOT/data/" \
+$REPO_ROOT/bin/core -server


### PR DESCRIPTION
Handles part of #20 

When `IS_DEV=true` is set the gitstore uri will be treated as a file uri. A new makefile target (`make run-dev`)is added to simplify running Core in dev mode. 