### PR TITLE
Local auth bypass

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ var defaultConfig = map[string]string{
 	"STORAGE_PROVIDER":            "google",
 	"GOOGLE_BUCKET_NAME":          "acm-core-resume",
 	"GOOGLE_SERVICE_ACCOUNT":      "",
-	"OAUTH_FAKE_USER":             "fake",
+	"OAUTH_FAKE_USER":             "fake@illinois.edu",
 }
 
 func GetConfigValue(key string) (string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ var defaultConfig = map[string]string{
 	"STORAGE_PROVIDER":            "google",
 	"GOOGLE_BUCKET_NAME":          "acm-core-resume",
 	"GOOGLE_SERVICE_ACCOUNT":      "",
+	"OAUTH_FAKE_USER":             "fake",
 }
 
 func GetConfigValue(key string) (string, error) {

--- a/controller/site/impl.go
+++ b/controller/site/impl.go
@@ -186,10 +186,22 @@ func (controller *SiteController) Sigs(ctx *context.Context) error {
 }
 
 func (controller *SiteController) Login(ctx *context.Context) error {
+	isDev, err := config.GetConfigValue("IS_DEV")
+	if err != nil {
+		return ctx.RenderError(
+			http.StatusBadRequest,
+			"Failed Checking Mode",
+			"could not determine if in dev mode",
+			err,
+		)
+	}
+
 	params := struct {
 		Authenticated bool
+		IsDev         bool
 	}{
 		Authenticated: ctx.LoggedIn,
+		IsDev:         isDev == "true",
 	}
 
 	return ctx.Render(http.StatusOK, "login", params)

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -11,4 +11,5 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 IS_DEV="true" \
 GITSTORE_BASE_URI="$REPO_ROOT/data/" \
+OAUTH_FAKE_USER="arnavs3@illinois.edu" \
 $REPO_ROOT/bin/core -server

--- a/service/auth/provider/fake.go
+++ b/service/auth/provider/fake.go
@@ -22,5 +22,5 @@ func (oauth *FakeOAuth) GetVerifiedEmail(token string) (string, error) {
 		return "", fmt.Errorf("failed to get fake user: %w", err)
 	}
 
-	return fmt.Sprintf("%s@illinois.edu", fakeUser), nil
+	return fakeUser, nil
 }

--- a/service/auth/provider/fake.go
+++ b/service/auth/provider/fake.go
@@ -1,5 +1,11 @@
 package provider
 
+import (
+	"fmt"
+
+	"github.com/acm-uiuc/core/config"
+)
+
 type FakeOAuth struct{}
 
 func (oauth *FakeOAuth) GetOAuthRedirect(target string) (string, error) {
@@ -11,5 +17,10 @@ func (oauth *FakeOAuth) GetOAuthToken(code string) (string, error) {
 }
 
 func (oauth *FakeOAuth) GetVerifiedEmail(token string) (string, error) {
-	return "fake@illinois.edu", nil
+	fakeUser, err := config.GetConfigValue("OAUTH_FAKE_USER")
+	if err != nil {
+		return "", fmt.Errorf("failed to get fake user: %w", err)
+	}
+
+	return fmt.Sprintf("%s@illinois.edu", fakeUser), nil
 }

--- a/service/auth/provider/interface.go
+++ b/service/auth/provider/interface.go
@@ -23,7 +23,12 @@ func GetProvider(provider string) (OAuthProvider, error) {
 		return nil, fmt.Errorf("failed to check if in test: %w", err)
 	}
 
-	if isTest == "true" {
+	isDev, err := config.GetConfigValue("IS_DEV")
+	if err != nil {
+		return nil, fmt.Errorf("failed to check if in dev: %w", err)
+	}
+
+	if isTest == "true" || isDev == "true" {
 		return &FakeOAuth{}, nil
 	}
 

--- a/template/login.html
+++ b/template/login.html
@@ -4,6 +4,7 @@
 <div id="login-container">
     <div class="row col-centered small-12 medium-4 large-4 login-form">
         <h3>Login</h3>
+        {{if not .IsDev}}
         <div>
             <p>
             Student / Faculty ACM@UIUC Members can log into the ACM intranet using their university provided Google account (netid@illinois.edu).
@@ -20,6 +21,16 @@
                 <button class="button">Login With LinkedIn</button>
             </a>
         </div>
+        {{else}}
+        <div>
+            <p>
+            Developers can login with an authentication bypass when dev mode is enabled
+            </p>
+            <a href="/api/auth/fake/redirect">
+                <button class="button">Login With Bypass</button>
+            </a>
+        </div>
+        {{end}}
     </div>
 </div>
 

--- a/template/login.html
+++ b/template/login.html
@@ -24,10 +24,18 @@
         {{else}}
         <div>
             <p>
-            Developers can login with an authentication bypass when dev mode is enabled
+            Developers can login with an student authentication bypass when dev mode is enabled
             </p>
             <a href="/api/auth/google/redirect">
-                <button class="button">Login With Bypass</button>
+                <button class="button">Login With Google</button>
+            </a>
+        </div>
+        <div>
+            <p>
+            Developers can login with an recruiter authentication bypass when dev mode is enabled
+            </p>
+            <a href="/api/auth/linkedin/redirect">
+                <button class="button">Login With LinkedIn</button>
             </a>
         </div>
         {{end}}

--- a/template/login.html
+++ b/template/login.html
@@ -26,7 +26,7 @@
             <p>
             Developers can login with an authentication bypass when dev mode is enabled
             </p>
-            <a href="/api/auth/fake/redirect">
+            <a href="/api/auth/google/redirect">
                 <button class="button">Login With Bypass</button>
             </a>
         </div>


### PR DESCRIPTION
Handles part of #20 

When `IS_DEV=true` is set, the login page will render an auth bypass button that automatically logs in the developer as the oauth fake user. The email for this user can be set with `OAUTH_FAKE_USER=<email>`.

Currently `make run-dev` will impersonate `arnavs3` for local development. 