### PR TITLE
Improve auth errors

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -28,7 +28,7 @@ func (ctx *Context) ErrorWithFormat(format ContextError, code int, title string,
 	default:
 		err := ctx.String(code, fmt.Sprintf("%s\n%s\n", title, message))
 		if err != nil {
-			fmt.Errorf("invalid error format: %s, failed to write string reponse: %w", format, err)
+			return fmt.Errorf("invalid error format: %s, failed to write string reponse: %w", format, err)
 		}
 
 		return fmt.Errorf("invalid error format: %s", format)

--- a/context/context.go
+++ b/context/context.go
@@ -12,6 +12,29 @@ type Context struct {
 	LoggedIn bool
 }
 
+type ContextError string
+
+const (
+	ContextErrorFormatJSON ContextError = "json"
+	ContextErrorFormatHTML ContextError = "html"
+)
+
+func (ctx *Context) ErrorWithFormat(format ContextError, code int, title string, message string, err error) error {
+	switch format {
+	case ContextErrorFormatJSON:
+		return ctx.JSONError(code, title, message, err)
+	case ContextErrorFormatHTML:
+		return ctx.RenderError(code, title, message, err)
+	default:
+		err := ctx.String(code, fmt.Sprintf("%s\n%s\n", title, message))
+		if err != nil {
+			fmt.Errorf("invalid error format: %s, failed to write string reponse: %w", format, err)
+		}
+
+		return fmt.Errorf("invalid error format: %s", format)
+	}
+}
+
 func (ctx *Context) RenderError(code int, title string, message string, err error) error {
 	params := struct {
 		Authenticated bool

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -79,7 +79,7 @@ func New(svc *service.Service) (*Controller, error) {
 
 	controller.GET(
 		"/api/user",
-		Chain(userController.GetUser, middleware.AuthorizeMatchAny(
+		Chain(userController.GetUser, middleware.AuthorizeMatchAnyAPI(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Marks: model.UserValidMarks,
 			},
@@ -91,7 +91,7 @@ func New(svc *service.Service) (*Controller, error) {
 	)
 	controller.GET(
 		"/api/user/filter",
-		Chain(userController.GetUsers, middleware.AuthorizeMatchAny(
+		Chain(userController.GetUsers, middleware.AuthorizeMatchAnyAPI(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Marks:      []string{model.UserMarkRecruiter},
 				Committees: []string{model.GroupTop4},
@@ -100,7 +100,7 @@ func New(svc *service.Service) (*Controller, error) {
 	)
 	controller.POST(
 		"/api/user/mark",
-		Chain(userController.MarkUser, middleware.AuthorizeMatchAny(
+		Chain(userController.MarkUser, middleware.AuthorizeMatchAnyAPI(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Committees: []string{model.GroupTop4},
 			},
@@ -108,7 +108,7 @@ func New(svc *service.Service) (*Controller, error) {
 	)
 	controller.DELETE(
 		"/api/user",
-		Chain(userController.DeleteUser, middleware.AuthorizeMatchAny(
+		Chain(userController.DeleteUser, middleware.AuthorizeMatchAnyAPI(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Committees: []string{model.GroupTop4},
 			},
@@ -130,7 +130,7 @@ func New(svc *service.Service) (*Controller, error) {
 	)
 	controller.GET(
 		"/api/resume/filter",
-		Chain(resumeController.GetResumes, middleware.AuthorizeMatchAny(
+		Chain(resumeController.GetResumes, middleware.AuthorizeMatchAnyAPI(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Marks:      []string{model.UserMarkRecruiter},
 				Committees: []string{model.GroupTop4},
@@ -139,7 +139,7 @@ func New(svc *service.Service) (*Controller, error) {
 	)
 	controller.POST(
 		"/api/resume/approve",
-		Chain(resumeController.ApproveResume, middleware.AuthorizeMatchAny(
+		Chain(resumeController.ApproveResume, middleware.AuthorizeMatchAnyAPI(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Committees: []string{model.GroupTop4},
 			},
@@ -203,7 +203,7 @@ func New(svc *service.Service) (*Controller, error) {
 
 	controller.GET(
 		"/resumebook",
-		Chain(siteController.ResumeBook, middleware.AuthorizeMatchAny(
+		Chain(siteController.ResumeBook, middleware.AuthorizeMatchAnyWebPage(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Marks:      []string{model.UserMarkRecruiter},
 				Committees: []string{model.GroupTop4},
@@ -213,7 +213,7 @@ func New(svc *service.Service) (*Controller, error) {
 
 	controller.GET(
 		"/intranet",
-		Chain(siteController.Intranet, middleware.AuthorizeMatchAny(
+		Chain(siteController.Intranet, middleware.AuthorizeMatchAnyWebPage(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Marks:      []string{model.UserMarkPaid},
 				Committees: []string{model.GroupTop4},
@@ -223,7 +223,7 @@ func New(svc *service.Service) (*Controller, error) {
 
 	controller.GET(
 		"/intranet/usermanager",
-		Chain(siteController.UserManager, middleware.AuthorizeMatchAny(
+		Chain(siteController.UserManager, middleware.AuthorizeMatchAnyWebPage(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Committees: []string{model.GroupTop4},
 			},
@@ -232,7 +232,7 @@ func New(svc *service.Service) (*Controller, error) {
 
 	controller.GET(
 		"/intranet/recruitercreator",
-		Chain(siteController.RecruiterCreator, middleware.AuthorizeMatchAny(
+		Chain(siteController.RecruiterCreator, middleware.AuthorizeMatchAnyWebPage(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Committees: []string{model.GroupTop4},
 			},
@@ -241,7 +241,7 @@ func New(svc *service.Service) (*Controller, error) {
 
 	controller.GET(
 		"/intranet/recruitermanager",
-		Chain(siteController.RecruiterManager, middleware.AuthorizeMatchAny(
+		Chain(siteController.RecruiterManager, middleware.AuthorizeMatchAnyWebPage(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Committees: []string{model.GroupTop4},
 			},
@@ -250,7 +250,7 @@ func New(svc *service.Service) (*Controller, error) {
 
 	controller.GET(
 		"/intranet/resumemanager",
-		Chain(siteController.ResumeManager, middleware.AuthorizeMatchAny(
+		Chain(siteController.ResumeManager, middleware.AuthorizeMatchAnyWebPage(
 			controller.svc, middleware.AuthorizeMatchParameters{
 				Committees: []string{model.GroupTop4},
 			},

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -40,11 +40,14 @@ func AuthorizeMatchAny(format context.ContextError, svc *service.Service, match 
 
 			isMarkMatch, err := hasMarkMatch(svc, ctx.Username, match.Marks)
 			if err != nil {
+				message := "could not find user marks; " +
+					"students: ensure you have filled out the join form to create an account; " +
+					"recruiters: please reach out to the corporate team for help creating an account"
 				return ctx.ErrorWithFormat(
 					format,
 					http.StatusForbidden,
 					"Failed Mark Match",
-					"could not find user marks",
+					message,
 					err,
 				)
 			}
@@ -61,11 +64,14 @@ func AuthorizeMatchAny(format context.ContextError, svc *service.Service, match 
 			}
 
 			if !isMarkMatch && !isCommitteeMatch {
+				message := "unauthorized attempt to access resource; " +
+					"students: please be patient as access to paid resources need to be manually granted by an administrator; " +
+					"recruiters: please reach out to the corporate team for help whitelisting account"
 				return ctx.ErrorWithFormat(
 					format,
 					http.StatusForbidden,
 					"Invalid Authorization Matches",
-					"unauthorized attempt to access resource",
+					message,
 					fmt.Errorf("unauthorized attempt to access resource"),
 				)
 			}

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -16,26 +16,58 @@ type AuthorizeMatchParameters struct {
 	Committees []string
 }
 
-func AuthorizeMatchAny(svc *service.Service, match AuthorizeMatchParameters) func(echo.HandlerFunc) echo.HandlerFunc {
+func AuthorizeMatchAnyAPI(svc *service.Service, match AuthorizeMatchParameters) func(echo.HandlerFunc) echo.HandlerFunc {
+	return AuthorizeMatchAny(context.ContextErrorFormatJSON, svc, match)
+}
+
+func AuthorizeMatchAnyWebPage(svc *service.Service, match AuthorizeMatchParameters) func(echo.HandlerFunc) echo.HandlerFunc {
+	return AuthorizeMatchAny(context.ContextErrorFormatHTML, svc, match)
+}
+
+func AuthorizeMatchAny(format context.ContextError, svc *service.Service, match AuthorizeMatchParameters) func(echo.HandlerFunc) echo.HandlerFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			ctx, ok := c.(*context.Context)
 			if !ok {
-				return ctx.String(http.StatusForbidden, "Invalid Context")
+				return ctx.ErrorWithFormat(
+					format,
+					http.StatusForbidden,
+					"Invalid Context",
+					"could not convert context",
+					fmt.Errorf("could not convert context"),
+				)
 			}
 
 			isMarkMatch, err := hasMarkMatch(svc, ctx.Username, match.Marks)
 			if err != nil {
-				return ctx.String(http.StatusForbidden, "Failed Mark Match")
+				return ctx.ErrorWithFormat(
+					format,
+					http.StatusForbidden,
+					"Failed Mark Match",
+					"could not find user marks",
+					err,
+				)
 			}
 
 			isCommitteeMatch, err := hasCommitteeMatch(svc, ctx.Username, match.Committees)
 			if err != nil {
-				return ctx.String(http.StatusForbidden, "Failed Committee Match")
+				return ctx.ErrorWithFormat(
+					format,
+					http.StatusForbidden,
+					"Failed Committee Match",
+					"could not find commitee information",
+					err,
+				)
 			}
 
 			if !isMarkMatch && !isCommitteeMatch {
-				return ctx.String(http.StatusForbidden, "Invalid Authorization Matches")
+				return ctx.ErrorWithFormat(
+					format,
+					http.StatusForbidden,
+					"Invalid Authorization Matches",
+					"unauthorized attempt to access resource",
+					fmt.Errorf("unauthorized attempt to access resource"),
+				)
 			}
 
 			return next(ctx)


### PR DESCRIPTION
Closes #19 

Adds logic to render the generated authentication error into the correct format depending on if the error occurs on an api endpoint or a web page endpoint.