### PR TITLE
Add timestamps to users and resumes table

### DIFF
--- a/controller/resume/impl.go
+++ b/controller/resume/impl.go
@@ -2,6 +2,7 @@ package resume
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/acm-uiuc/core/context"
 	"github.com/acm-uiuc/core/model"
@@ -33,6 +34,7 @@ func (controller *ResumeController) UploadResume(ctx *context.Context) error {
 
 	req.BlobKey = req.Username
 	req.Approved = false
+	req.UpdatedAt = time.Now().Unix()
 
 	uri, err := controller.svc.Resume.UploadResume(req)
 	if err != nil {

--- a/controller/site/impl.go
+++ b/controller/site/impl.go
@@ -3,6 +3,7 @@ package site
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/acm-uiuc/core/config"
 	"github.com/acm-uiuc/core/context"
@@ -266,12 +267,30 @@ func (controller *SiteController) UserManager(ctx *context.Context) error {
 		)
 	}
 
+	extendedUsers := []struct {
+		model.User
+		HumanTimestamp string
+	}{}
+
+	for _, user := range users {
+		extendedUsers = append(extendedUsers, struct {
+			model.User
+			HumanTimestamp string
+		}{
+			User:           user,
+			HumanTimestamp: time.Unix(user.CreatedAt, 0).Format(time.UnixDate),
+		})
+	}
+
 	params := struct {
 		Authenticated bool
-		Users         []model.User
+		Users         []struct {
+			model.User
+			HumanTimestamp string
+		}
 	}{
 		Authenticated: ctx.LoggedIn,
-		Users:         users,
+		Users:         extendedUsers,
 	}
 
 	return ctx.Render(http.StatusOK, "usermanager", params)
@@ -462,12 +481,30 @@ func (controller *SiteController) ResumeManager(ctx *context.Context) error {
 		)
 	}
 
+	extendedResumes := []struct {
+		model.Resume
+		HumanTimestamp string
+	}{}
+
+	for _, resume := range resumes {
+		extendedResumes = append(extendedResumes, struct {
+			model.Resume
+			HumanTimestamp string
+		}{
+			Resume:         resume,
+			HumanTimestamp: time.Unix(resume.UpdatedAt, 0).Format(time.UnixDate),
+		})
+	}
+
 	params := struct {
 		Authenticated bool
-		Resumes       []model.Resume
+		Resumes       []struct {
+			model.Resume
+			HumanTimestamp string
+		}
 	}{
 		Authenticated: ctx.LoggedIn,
-		Resumes:       resumes,
+		Resumes:       extendedResumes,
 	}
 
 	return ctx.Render(http.StatusOK, "resumemanager", params)

--- a/controller/user/impl.go
+++ b/controller/user/impl.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/acm-uiuc/core/context"
 	"github.com/acm-uiuc/core/model"
@@ -46,6 +47,7 @@ func (controller *UserController) CreateUser(ctx *context.Context) error {
 	}
 
 	req.Mark = model.UserMarkBasic
+	req.CreatedAt = time.Now().Unix()
 
 	err = controller.svc.User.CreateUser(req)
 	if err != nil {

--- a/database/migration/add_resumes_timestamp.go
+++ b/database/migration/add_resumes_timestamp.go
@@ -1,0 +1,5 @@
+package migration
+
+const add_resumes_timestamp = `
+ALTER TABLE resumes ADD updated_at BIGINT NOT NULL;
+`

--- a/database/migration/add_users_timestamp.go
+++ b/database/migration/add_users_timestamp.go
@@ -1,0 +1,5 @@
+package migration
+
+const add_users_timestamp = `
+ALTER TABLE users ADD created_at BIGINT NOT NULL;
+`

--- a/database/migration/migrations.go
+++ b/database/migration/migrations.go
@@ -15,6 +15,8 @@ var migrations []migration = []migration{
 	migration{name: "create_tokens_table", command: create_tokens_table},
 	migration{name: "create_users_table", command: create_users_table},
 	migration{name: "create_resumes_table", command: create_resumes_table},
+	migration{name: "add_users_timestamp", command: add_users_timestamp},
+	migration{name: "add_resumes_timestamp", command: add_resumes_timestamp},
 }
 
 func Migrate(startName string) error {

--- a/model/resume.go
+++ b/model/resume.go
@@ -12,4 +12,5 @@ type Resume struct {
 	Seeking         string `db:"seeking" json:"seeking"`
 	BlobKey         string `db:"blob_key" json:"blob_key"`
 	Approved        bool   `db:"approved" json:"approved"`
+	UpdatedAt       int64  `db:"updated_at" json:"updated_at"`
 }

--- a/model/user.go
+++ b/model/user.go
@@ -5,6 +5,7 @@ type User struct {
 	FirstName string `db:"first_name" json:"first_name"`
 	LastName  string `db:"last_name" json:"last_name"`
 	Mark      string `db:"mark" json:"mark"`
+	CreatedAt int64  `db:"created_at" json:"created_at"`
 }
 
 const (

--- a/service/resume/impl.go
+++ b/service/resume/impl.go
@@ -66,7 +66,7 @@ func (service *resumeImpl) validateResume(resume *model.Resume) error {
 }
 
 func (service *resumeImpl) addResume(resume *model.Resume) error {
-	_, err := service.db.NamedExec("INSERT INTO resumes (username, first_name, last_name, email, graduation_month, graduation_year, major, degree, seeking, blob_key, approved) VALUES (:username, :first_name, :last_name, :email, :graduation_month, :graduation_year, :major, :degree, :seeking, :blob_key, :approved) ON DUPLICATE KEY UPDATE username = :username, first_name = :first_name, last_name = :last_name, email = :email, graduation_month = :graduation_month, graduation_year = :graduation_year, major = :major, degree = :degree, seeking = :seeking, blob_key = :blob_key, approved = :approved", resume)
+	_, err := service.db.NamedExec("INSERT INTO resumes (username, first_name, last_name, email, graduation_month, graduation_year, major, degree, seeking, blob_key, approved, updated_at) VALUES (:username, :first_name, :last_name, :email, :graduation_month, :graduation_year, :major, :degree, :seeking, :blob_key, :approved, :updated_at) ON DUPLICATE KEY UPDATE username = :username, first_name = :first_name, last_name = :last_name, email = :email, graduation_month = :graduation_month, graduation_year = :graduation_year, major = :major, degree = :degree, seeking = :seeking, blob_key = :blob_key, approved = :approved, updated_at = :updated_at", resume)
 	if err != nil {
 		fmt.Errorf("failed to add resume to database: %w", err)
 	}

--- a/service/user/impl.go
+++ b/service/user/impl.go
@@ -86,7 +86,7 @@ func (service *userImpl) validateUser(user *model.User) error {
 }
 
 func (service *userImpl) addUser(user *model.User) error {
-	_, err := service.db.NamedExec("INSERT INTO users (username, first_name, last_name, mark) VALUES (:username, :first_name, :last_name, :mark)", user)
+	_, err := service.db.NamedExec("INSERT INTO users (username, first_name, last_name, mark, created_at) VALUES (:username, :first_name, :last_name, :mark, :created_at)", user)
 	if err != nil {
 		fmt.Errorf("failed to add user to database: %w", err)
 	}

--- a/template/resumemanager.html
+++ b/template/resumemanager.html
@@ -15,6 +15,7 @@
                             <th>Graduation </th>
                             <th>Level </th>
                             <th>Seeking </th>
+                            <th>Last Updated </th>
                             <th>Resume </th>
                         </tr>
                     </thead>
@@ -33,6 +34,7 @@
                             <td>{{.GraduationMonth}} / {{.GraduationYear}}</td>
                             <td>{{.Degree}}</td>
                             <td>{{.Seeking}}</td>
+                            <td>{{.HumanTimestamp}}</td>
                             <td><a href="{{.BlobKey}}" target="_blank">View Resume</a></td>
                         </tr>
                     {{end}}

--- a/template/usermanager.html
+++ b/template/usermanager.html
@@ -31,7 +31,7 @@
                                     <td>{{.Username}}</td>
                                     <td>{{.FirstName}}</td>
                                     <td>{{.LastName}}</td>
-                                    <td>0</td>
+                                    <td>{{.HumanTimestamp}}</td>
                                 </tr>
                             {{end}}
                         </tbody>

--- a/test/service/resume/resume_test.go
+++ b/test/service/resume/resume_test.go
@@ -48,6 +48,7 @@ func TestCreateAndGetresumes(t *testing.T) {
 		Seeking:         "Full Time",
 		BlobKey:         "fake1",
 		Approved:        false,
+		UpdatedAt:       10,
 	}
 
 	expectedResumeTwo := model.Resume{
@@ -62,6 +63,7 @@ func TestCreateAndGetresumes(t *testing.T) {
 		Seeking:         "Internship",
 		BlobKey:         "fake2",
 		Approved:        false,
+		UpdatedAt:       20,
 	}
 
 	_, err = svc.UploadResume(expectedResumeOne)
@@ -115,6 +117,7 @@ func TestCreateAndApproveAndGetresume(t *testing.T) {
 		Seeking:         "Full Time",
 		BlobKey:         "fake1",
 		Approved:        false,
+		UpdatedAt:       10,
 	}
 
 	_, err = svc.UploadResume(expectedResumeOne)

--- a/test/service/user/user_test.go
+++ b/test/service/user/user_test.go
@@ -41,6 +41,7 @@ func TestCreateAndGetUser(t *testing.T) {
 		FirstName: "fake",
 		LastName:  "fake",
 		Mark:      model.UserMarkBasic,
+		CreatedAt: 10,
 	}
 
 	err = svc.CreateUser(expectedUser)
@@ -74,6 +75,7 @@ func TestCreateAndGetUsers(t *testing.T) {
 		FirstName: "fake1",
 		LastName:  "fake1",
 		Mark:      model.UserMarkBasic,
+		CreatedAt: 10,
 	}
 
 	expectedUserTwo := model.User{
@@ -81,6 +83,7 @@ func TestCreateAndGetUsers(t *testing.T) {
 		FirstName: "fake2",
 		LastName:  "fake2",
 		Mark:      model.UserMarkBasic,
+		CreatedAt: 20,
 	}
 
 	err = svc.CreateUser(expectedUserOne)
@@ -124,6 +127,7 @@ func TestCreateAndMarkAndGetUser(t *testing.T) {
 		FirstName: "fake",
 		LastName:  "fake",
 		Mark:      model.UserMarkBasic,
+		CreatedAt: 10,
 	}
 
 	err = svc.CreateUser(expectedUser)
@@ -173,6 +177,7 @@ func TestCreateAndGetAndRemoveAndGetUser(t *testing.T) {
 		FirstName: "fake",
 		LastName:  "fake",
 		Mark:      model.UserMarkBasic,
+		CreatedAt: 10,
 	}
 
 	err = svc.CreateUser(expectedUser)


### PR DESCRIPTION
Closes #16 
Closes #17 

Adds `created_at` timestamp to the user data and adds a `updated_at` timestamp to the resume data. These timestamps are injected in the `CreateUser` and `UploadResume` endpoints. These timestamps are displayed in the user manager and the resume manager.