### PR TITLE
Shorten home page terminal message

### DIFF
--- a/template/home.html
+++ b/template/home.html
@@ -7,7 +7,7 @@
   <div id="term-padding">
   </div>
   <div id="terminal">
-    acm@uiuc$ echo 'Welcome to ACM@UIUC'
+    acm@uiuc$ Welcome!
     <span id="shell"></span>
   </div>
 </div>


### PR DESCRIPTION
The message on the home page is rather long can cause the line to wrap. This change reverts the message to the original 'Welcome!' that was in the prior version of the website.