### PR TITLE
Improved login workflows

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -213,11 +213,7 @@ func New(svc *service.Service) (*Controller, error) {
 
 	controller.GET(
 		"/intranet",
-		Chain(siteController.Intranet, middleware.AuthorizeMatchAnyWebPage(
-			controller.svc, middleware.AuthorizeMatchParameters{
-				Marks: model.UserValidMarks,
-			},
-		)),
+		Chain(siteController.Intranet),
 	)
 
 	controller.GET(

--- a/controller/site/impl.go
+++ b/controller/site/impl.go
@@ -340,12 +340,7 @@ func (controller *SiteController) Intranet(ctx *context.Context) error {
 
 	user, err := controller.svc.User.GetUser(ctx.Username)
 	if err != nil {
-		return ctx.RenderError(
-			http.StatusBadRequest,
-			"Failed Getting User",
-			"could not get user data",
-			err,
-		)
+		return fmt.Errorf("intranet error: %s, join error: %w ", err.Error(), controller.Join(ctx))
 	}
 
 	markRole, ok := marksToRole[user.Mark]

--- a/service/user/impl.go
+++ b/service/user/impl.go
@@ -88,7 +88,7 @@ func (service *userImpl) validateUser(user *model.User) error {
 func (service *userImpl) addUser(user *model.User) error {
 	_, err := service.db.NamedExec("INSERT INTO users (username, first_name, last_name, mark, created_at) VALUES (:username, :first_name, :last_name, :mark, :created_at)", user)
 	if err != nil {
-		fmt.Errorf("failed to add user to database: %w", err)
+		return fmt.Errorf("failed to add user to database: %w", err)
 	}
 
 	return nil
@@ -101,7 +101,7 @@ func (service *userImpl) removeUser(username string) error {
 
 	_, err := service.db.NamedExec("DELETE FROM users WHERE username = :username", user)
 	if err != nil {
-		fmt.Errorf("failed to remove user from database: %w", err)
+		return fmt.Errorf("failed to remove user from database: %w", err)
 	}
 
 	return nil

--- a/template/join.html
+++ b/template/join.html
@@ -59,7 +59,7 @@
             }).then(res => {
                 return res.json();
             }).then(data => {
-                window.location.replace("/");
+                window.location.replace("/intranet");
             });
         }
     </script>

--- a/template/login.html
+++ b/template/login.html
@@ -9,7 +9,7 @@
             <p>
             Student / Faculty ACM@UIUC Members can log into the ACM intranet using their university provided Google account (netid@illinois.edu).
             </p>
-            <a href="/api/auth/google">
+            <a href="/api/auth/google?target=/intranet">
                 <button class="button">Login With Google</button>
             </a>
         </div><br/>
@@ -17,7 +17,7 @@
             <p>
             Recruiters who sponsor ACM@UIUC can login with their LinkedIn account and request access to view the ACM@UIUC resume book.
             </p>
-            <a href="/api/auth/linkedin">
+            <a href="/api/auth/linkedin?target=/intranet">
                 <button class="button">Login With LinkedIn</button>
             </a>
         </div>
@@ -26,7 +26,7 @@
             <p>
             Developers can login with an student authentication bypass when dev mode is enabled
             </p>
-            <a href="/api/auth/google/redirect">
+            <a href="/api/auth/google/redirect?state=/intranet">
                 <button class="button">Login With Google</button>
             </a>
         </div>
@@ -34,7 +34,7 @@
             <p>
             Developers can login with an recruiter authentication bypass when dev mode is enabled
             </p>
-            <a href="/api/auth/linkedin/redirect">
+            <a href="/api/auth/linkedin/redirect?state=/intranet">
                 <button class="button">Login With LinkedIn</button>
             </a>
         </div>


### PR DESCRIPTION
This PR makes the following changes to the login workflow:

- Successful logins are redirected to `/intranet`
- If a user has not filled out the join form `/intranet` renders the join form
- Filling out the join form redirects to `/intranet`