### PR TITLE
Improve login and signup redirects

### DIFF
--- a/controller/site/impl.go
+++ b/controller/site/impl.go
@@ -330,17 +330,21 @@ func (controller *SiteController) RecruiterManager(ctx *context.Context) error {
 }
 
 func (controller *SiteController) Intranet(ctx *context.Context) error {
+	if !ctx.LoggedIn {
+		return ctx.Redirect(http.StatusFound, "/login")
+	}
+
+	user, err := controller.svc.User.GetUser(ctx.Username)
+	if err != nil {
+		return fmt.Errorf("intranet error: %s, redirect error: %w ", err.Error(), ctx.Redirect(http.StatusFound, "/join"))
+	}
+
 	roles := []string{}
 
 	marksToRole := map[string]string{
 		model.UserMarkBasic:     "Basic Member",
 		model.UserMarkPaid:      "Paid Member",
 		model.UserMarkRecruiter: "Recruiter",
-	}
-
-	user, err := controller.svc.User.GetUser(ctx.Username)
-	if err != nil {
-		return fmt.Errorf("intranet error: %s, join error: %w ", err.Error(), controller.Join(ctx))
 	}
 
 	markRole, ok := marksToRole[user.Mark]


### PR DESCRIPTION
This PR further improves the redirects which occur during first-time login and signup. Hitting `/intranet` will now first check for if the user is logged-in. If not then the user is redirected to the login page. If the user is logged-in, but has not filled our the join form then they are redirected to the join form. Filling out the join form / logging in will still redirect to `/intranet`.