### PR TITLE
Parallel resume uri signing

### DIFF
--- a/service/resume/impl.go
+++ b/service/resume/impl.go
@@ -11,6 +11,10 @@ import (
 	"github.com/acm-uiuc/core/service/resume/provider"
 )
 
+const (
+	signerParallelism = 8
+)
+
 type resumeImpl struct {
 	db *sqlx.DB
 }
@@ -101,18 +105,45 @@ func (service *resumeImpl) getFilteredResumes(filterStrings map[string][]string)
 			return nil, fmt.Errorf("failed to decode row from database: %w", err)
 		}
 
-		uri, err := service.getSignedUri(result.BlobKey, "GET")
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate signed uri for resume: %w", err)
-		}
-		result.BlobKey = uri
-
 		results = append(results, result)
 	}
 
 	err = rows.Err()
 	if err != nil {
 		return nil, fmt.Errorf("failed reading rows from database: %w", err)
+	}
+
+	signerInputs := make(chan int, len(results))
+	signerOutputs := make(chan error, len(results))
+
+	signerWorker := func(inputs <-chan int, outputs chan<- error) {
+		for input := range inputs {
+			uri, err := service.getSignedUri(results[input].BlobKey, "GET")
+			results[input].BlobKey = uri
+			outputs <- err
+		}
+	}
+
+	for i := 0; i < signerParallelism; i++ {
+		go signerWorker(signerInputs, signerOutputs)
+	}
+
+	for i := 0; i < len(results); i++ {
+		signerInputs <- i
+	}
+	close(signerInputs)
+
+	var firstError error
+	for i := 0; i < len(results); i++ {
+		err := <-signerOutputs
+		if firstError == nil && err != nil {
+			firstError = err
+		}
+	}
+	close(signerOutputs)
+
+	if firstError != nil {
+		return nil, fmt.Errorf("failed to generate signed uri for resume: %w", err)
 	}
 
 	return results, nil

--- a/service/resume/impl.go
+++ b/service/resume/impl.go
@@ -143,7 +143,7 @@ func (service *resumeImpl) getFilteredResumes(filterStrings map[string][]string)
 	close(signerOutputs)
 
 	if firstError != nil {
-		return nil, fmt.Errorf("failed to generate signed uri for resume: %w", err)
+		return nil, fmt.Errorf("failed to generate signed uri for resume: %w", firstError)
 	}
 
 	return results, nil

--- a/service/resume/impl.go
+++ b/service/resume/impl.go
@@ -70,8 +70,6 @@ func (service *resumeImpl) validateResume(resume *model.Resume) error {
 		return fmt.Errorf("resume blob key should be the username: %s", resume.BlobKey)
 	}
 
-	// TODO: Enforce more validation on resumes
-
 	return nil
 }
 

--- a/service/resume/impl.go
+++ b/service/resume/impl.go
@@ -67,7 +67,7 @@ func (service *resumeImpl) validateResume(resume *model.Resume) error {
 	}
 
 	if resume.BlobKey != resume.Username {
-		return fmt.Errorf("resume blob key should be the username: %w", resume.BlobKey)
+		return fmt.Errorf("resume blob key should be the username: %s", resume.BlobKey)
 	}
 
 	// TODO: Enforce more validation on resumes

--- a/service/user/impl.go
+++ b/service/user/impl.go
@@ -80,8 +80,6 @@ func (service *userImpl) validateUser(user *model.User) error {
 		return fmt.Errorf("invalid username: %s", user.Username)
 	}
 
-	// TODO: Implement further user data validate
-
 	return nil
 }
 


### PR DESCRIPTION
Loading the resume book is currently much slower than loading the user manager page even though there is much more data in the user manager page. The reason for this is likely the serial signing of URIs for the resumes.

This PR parallelizes that signing process over eight worker routines in order to reduce that overhead.